### PR TITLE
ci: use main as new master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '0 2 * * 1-5'
 


### PR DESCRIPTION
Signed-off-by: Sebastien Binet <binet@cern.ch>