### PR TITLE
canbus: add SetFilters

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -7,6 +7,7 @@ package canbus
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 
@@ -40,6 +41,17 @@ func (sck *Socket) Name() string {
 		return "N/A"
 	}
 	return sck.iface.Name
+}
+
+// SetFilters sets the CAN_RAW_FILTER option and applies the provided
+// filters to the underlying socket.
+func (sck *Socket) SetFilters(filters []unix.CanFilter) error {
+	err := unix.SetsockoptCanRawFilter(sck.dev.fd, unix.SOL_CAN_RAW, unix.CAN_RAW_FILTER, filters)
+	if err != nil {
+		return fmt.Errorf("could not set CAN filters: %w", err)
+	}
+
+	return nil
 }
 
 // Close closes the CAN bus socket.

--- a/socket_example_test.go
+++ b/socket_example_test.go
@@ -1,0 +1,207 @@
+// Copyright 2022 The go-daq Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package canbus_test
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/go-daq/canbus"
+	"golang.org/x/sys/unix"
+)
+
+func ExampleSocket() {
+	recv, err := canbus.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer recv.Close()
+
+	send, err := canbus.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer send.Close()
+
+	err = recv.Bind("vcan0")
+	if err != nil {
+		log.Fatalf("could not bind recv socket: %+v", err)
+	}
+
+	err = send.Bind("vcan0")
+	if err != nil {
+		log.Fatalf("could not bind send socket: %+v", err)
+	}
+
+	for i := 0; i < 5; i++ {
+		_, err := send.Send(canbus.Frame{
+			ID:   0x123,
+			Data: []byte(fmt.Sprintf("data-%02d", i)),
+			Kind: canbus.SFF,
+		})
+		if err != nil {
+			log.Fatalf("could not send frame %d: %+v", i, err)
+		}
+	}
+
+	for i := 0; i < 5; i++ {
+		frame, err := recv.Recv()
+		if err != nil {
+			log.Fatalf("could not recv frame %d: %+v", i, err)
+		}
+		fmt.Printf("frame-%02d: %q (id=0x%x)\n", i, frame.Data, frame.ID)
+	}
+
+	// Output:
+	// frame-00: "data-00" (id=0x123)
+	// frame-01: "data-01" (id=0x123)
+	// frame-02: "data-02" (id=0x123)
+	// frame-03: "data-03" (id=0x123)
+	// frame-04: "data-04" (id=0x123)
+}
+
+func ExampleSocket_eFF() {
+	recv, err := canbus.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer recv.Close()
+
+	send, err := canbus.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer send.Close()
+
+	err = recv.Bind("vcan0")
+	if err != nil {
+		log.Fatalf("could not bind recv socket: %+v", err)
+	}
+
+	err = send.Bind("vcan0")
+	if err != nil {
+		log.Fatalf("could not bind send socket: %+v", err)
+	}
+
+	for i := 0; i < 5; i++ {
+		_, err := send.Send(canbus.Frame{
+			ID:   0x1234567,
+			Data: []byte(fmt.Sprintf("data-%02d", i)),
+			Kind: canbus.EFF,
+		})
+		if err != nil {
+			log.Fatalf("could not send frame %d: %+v", i, err)
+		}
+	}
+
+	for i := 0; i < 5; i++ {
+		frame, err := recv.Recv()
+		if err != nil {
+			log.Fatalf("could not recv frame %d: %+v", i, err)
+		}
+		fmt.Printf("frame-%02d: %q (id=0x%x)\n", i, frame.Data, frame.ID)
+	}
+
+	// Output:
+	// frame-00: "data-00" (id=0x1234567)
+	// frame-01: "data-01" (id=0x1234567)
+	// frame-02: "data-02" (id=0x1234567)
+	// frame-03: "data-03" (id=0x1234567)
+	// frame-04: "data-04" (id=0x1234567)
+}
+
+func ExampleSocket_setFilters() {
+	recv1, err := canbus.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer recv1.Close()
+
+	err = recv1.SetFilters([]unix.CanFilter{
+		{Id: 0x123, Mask: unix.CAN_SFF_MASK},
+	})
+	if err != nil {
+		log.Fatalf("could not set CAN filters: %+v", err)
+	}
+
+	recv2, err := canbus.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer recv2.Close()
+
+	err = recv2.SetFilters([]unix.CanFilter{
+		{Id: 0x123 | unix.CAN_INV_FILTER, Mask: unix.CAN_SFF_MASK},
+	})
+	if err != nil {
+		log.Fatalf("could not set CAN filters: %+v", err)
+	}
+
+	send, err := canbus.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer send.Close()
+
+	err = recv1.Bind("vcan0")
+	if err != nil {
+		log.Fatalf("could not bind recv socket: %+v", err)
+	}
+
+	err = recv2.Bind("vcan0")
+	if err != nil {
+		log.Fatalf("could not bind recv socket: %+v", err)
+	}
+
+	err = send.Bind("vcan0")
+	if err != nil {
+		log.Fatalf("could not bind send socket: %+v", err)
+	}
+
+	for i := 0; i < 6; i++ {
+		var id uint32 = 0x123
+		if i%2 == 0 {
+			id = 0x321
+		}
+		_, err := send.Send(canbus.Frame{
+			ID:   id,
+			Data: []byte(fmt.Sprintf("data-%02d", i)),
+			Kind: canbus.SFF,
+		})
+		if err != nil {
+			log.Fatalf("could not send frame %d: %+v", i, err)
+		}
+	}
+
+	fmt.Printf("recv1:\n")
+	for i := 0; i < 3; i++ {
+		frame, err := recv1.Recv()
+		if err != nil {
+			log.Fatalf("could not recv frame %d: %+v", i, err)
+		}
+		fmt.Printf("frame-%02d: %q (id=0x%x)\n", i, frame.Data, frame.ID)
+	}
+
+	fmt.Printf("\n")
+	fmt.Printf("recv2:\n")
+	for i := 0; i < 3; i++ {
+		frame, err := recv2.Recv()
+		if err != nil {
+			log.Fatalf("could not recv frame %d: %+v", i, err)
+		}
+		fmt.Printf("frame-%02d: %q (id=0x%x)\n", i, frame.Data, frame.ID)
+	}
+
+	// Output:
+	// recv1:
+	// frame-00: "data-01" (id=0x123)
+	// frame-01: "data-03" (id=0x123)
+	// frame-02: "data-05" (id=0x123)
+	//
+	// recv2:
+	// frame-00: "data-00" (id=0x321)
+	// frame-01: "data-02" (id=0x321)
+	// frame-02: "data-04" (id=0x321)
+}


### PR DESCRIPTION
This CL adds the SetFilters API around the setsockopt(3) UNIX call.

Signed-off-by: Sebastien Binet <binet@cern.ch>

Fixes #1.